### PR TITLE
Cope with request.args being a dict rather than a multidict

### DIFF
--- a/ucam_webauth/flask_glue.py
+++ b/ucam_webauth/flask_glue.py
@@ -304,7 +304,8 @@ class AuthDecorator(object):
         if "WLS-Response" in request.args:
             if request.method != "GET":
                 abort(405)
-            if len(request.args.getlist("WLS-Response")) != 1:
+            if hasattr(request.args, "getlist") and \
+                    len(request.args.getlist("WLS-Response")) != 1:
                 abort(400)
 
             if "_ucam_webauth" not in session:


### PR DESCRIPTION
I use `flask.request.parameter_storage_class = werkzeug.datastructures.ImmutableDict`; that upsets ucam_webauth.flask_glue as it expects request.args to have a getlist().

Note that in the case of no request.args.getlist(), I'm omitting the check for multiple WLS-Response arguments (ImmutableDict will just give the first one).  I believe that's OK as it is still checked for validity; any attempt to pass two WLS-Responses could achieve nothing untoward.
