### PR TITLE
Make this thing build on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os.path
+import os
 from setuptools import setup, Extension
 
 filename = os.path.join(os.path.dirname(__file__), 'description.rst')
@@ -7,7 +8,7 @@ with open(filename) as f:
 
 rsamodule = Extension('ucam_webauth.rsa',
                       sources=['ucam_webauth/rsa.c'],
-                      libraries=["ssl", "crypto"])
+                      libraries=["ssl", "crypto"] if os.name != 'nt' else ["libeay32"])
 
 setup(
     name = "python-raven",


### PR DESCRIPTION
Other things required that can't go in the repository:
1. A sane environment (64-bit Python 27 is [a bit of a pain](https://stackoverflow.com/q/11267463/102441)) that is already capable of building simple C extensions
2. An installation of [OpenSSL](http://slproweb.com/products/Win32OpenSSL.html) that matches your python bitness
3. The following sequence of commands before running `pip`
   
   ```
   > set LIB=<path-to-openssl>/lib;%LIB%
   > set INCLUDE=<path-to-openssl>/include;%INCLUDE%
   ```

That should probably go in a readme somewhere
