### PR TITLE
Fix incomplete module path in simple_demo

### DIFF
--- a/simple_demo/app.py
+++ b/simple_demo/app.py
@@ -27,7 +27,7 @@ app.add_template_global(getattr, name="getattr")
 
 modules = {"ucam_webauth": ucam_webauth,
            "ucam_webauth.raven": ucam_webauth.raven, 
-           "ucam_webauth.raven.demoserver": raven.demoserver}
+           "ucam_webauth.raven.demoserver": ucam_webauth.raven.demoserver}
 
 auth_decorator = ucam_webauth.raven.flask_glue.AuthDecorator()
 


### PR DESCRIPTION
The `simple_demo` application was failing with this error:

```
Traceback (most recent call last):
  File "app.py", line 30, in <module>
    "ucam_webauth.raven.demoserver": raven.demoserver}
NameError: name 'raven' is not defined
```

I assume this is a remnant from the big `raven -> ucam_webauth.raven` rename; this commit seems to fix (i.e. the webapp runs).