### PR TITLE
Unbreak tests by removing an incorrect assumption

### DIFF
--- a/tests/test_auth_decorator.py
+++ b/tests/test_auth_decorator.py
@@ -963,7 +963,9 @@ class TestAuthDecorator(object):
 
             # ... now pick the first auth back up again and complete it
             # https://github.com/mitsuhiko/flask/issues/968
-            url = redir.location[len("http://localhost"):]
+            url = redir.location
+            if url.startswith("http://localhost"):
+                url = url[len("http://localhost"):]
             response = client.get(url, follow_redirects=True)
             assert response.status_code == 200
 


### PR DESCRIPTION
Some library change caused `redir.location` not to become fully-qualified, i.e. at this point in the code it's now "/fake_wls?..." rather than "http://localhost/fake_wls?...".  Let's not blindly remove the URL prefix before checking it's there.